### PR TITLE
Add support for 64-bit double word read/write

### DIFF
--- a/README
+++ b/README
@@ -6,7 +6,7 @@ to memory registers on a PCI card.
 Usage:	./pcimem { sys file } { offset } [ type [ data ] ]
 	sys file: sysfs file for the pci resource to act on
 	offset  : offset into pci memory region to act upon
-	type    : access operation type : [b]yte, [h]alfword, [w]ord
+	type    : access operation type : [b]yte, [h]alfword, [w]ord, [d]ouble-word
 	data    : data to be written
 
 == Platform Support ==

--- a/pcimem.c
+++ b/pcimem.c
@@ -47,10 +47,11 @@
 int main(int argc, char **argv) {
 	int fd;
 	void *map_base, *virt_addr;
-	uint32_t read_result, writeval;
+	uint64_t read_result, writeval;
 	char *filename;
 	off_t target;
 	int access_type = 'w';
+	int type_width;
 
 	if(argc < 3) {
 		// pcimem /sys/bus/pci/devices/0001\:00\:07.0/resource0 0x100 w 0x00
@@ -58,7 +59,7 @@ int main(int argc, char **argv) {
 		fprintf(stderr, "\nUsage:\t%s { sys file } { offset } [ type [ data ] ]\n"
 			"\tsys file: sysfs file for the pci resource to act on\n"
 			"\toffset  : offset into pci memory region to act upon\n"
-			"\ttype    : access operation type : [b]yte, [h]alfword, [w]ord\n"
+			"\ttype    : access operation type : [b]yte, [h]alfword, [w]ord, [d]ouble-word\n"
 			"\tdata    : data to be written\n\n",
 			argv[0]);
 		exit(1);
@@ -85,22 +86,30 @@ int main(int argc, char **argv) {
     switch(access_type) {
 		case 'b':
 			read_result = *((uint8_t *) virt_addr);
+			type_width = 2;
 			break;
 		case 'h':
 			read_result = *((uint16_t *) virt_addr);
+			type_width = 4;
 			break;
 		case 'w':
 			read_result = *((uint32_t *) virt_addr);
+			type_width = 8;
+			break;
+                case 'd':
+			read_result = *((uint64_t *) virt_addr);
+			type_width = 16;
 			break;
 		default:
 			fprintf(stderr, "Illegal data type '%c'.\n", access_type);
 			exit(2);
 	}
-    printf("Value at offset 0x%X (%p): 0x%X\n", (int) target, virt_addr, read_result);
+    printf("Value at offset 0x%X (%p): 0x%0*lX\n", (int) target, virt_addr, type_width,
+	   read_result);
     fflush(stdout);
 
 	if(argc > 4) {
-		writeval = strtoul(argv[4], 0, 0);
+		writeval = strtoull(argv[4], NULL, 0);
 		switch(access_type) {
 			case 'b':
 				*((uint8_t *) virt_addr) = writeval;
@@ -114,8 +123,13 @@ int main(int argc, char **argv) {
 				*((uint32_t *) virt_addr) = writeval;
 				read_result = *((uint32_t *) virt_addr);
 				break;
+			case 'd':
+				*((uint64_t *) virt_addr) = writeval;
+				read_result = *((uint64_t *) virt_addr);
+				break;
 		}
-		printf("Written 0x%X; readback 0x%X\n", writeval, read_result);
+		printf("Written 0x%0*lX; readback 0x%*lX\n", type_width,
+		       writeval, type_width, read_result);
 		fflush(stdout);
 	}
 


### PR DESCRIPTION
This pull request adds support for reading/writing 64-bit unsigned integers
from the PCI device registers. This access mode can be used via the
newly introduced '-d' access type.

Signed-off-by: Vaibhav Jain <vaibhav@linux.vnet.ibm.com>